### PR TITLE
[bugfix] Improve package script mapping strategy

### DIFF
--- a/Editor/GUID/SyncOperationPlanner.cs
+++ b/Editor/GUID/SyncOperationPlanner.cs
@@ -451,7 +451,7 @@ namespace DivineDragon
                 else if (existingAssemblyNames.Contains(assemblyName))
                 {
                     string assemblyFolder = AssemblyUtils.GetAssemblyFolder(filePath);
-                    var mappings = ScriptUtils.CreateStubToRealGuidMappings(assemblyFolder, assemblyName);
+                    var mappings = ScriptUtils.CreateStubToRealGuidMappings(assemblyFolder);
                     plan.StubScriptMappings.AddRange(mappings);
 
                     skipFolders.Add(assemblyFolder);

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 1.0.2
+- Allow components like `UniversalAdditionalCameraData` from `com.unity.render-pipelines.universal` to be correctly re-mapped - before this fix only the first class of the file could actually be matched.
+
 ## 1.0.1
 - Clean up the dumped AssetRipper project unless in Dev mode, toggleable in settings. 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.divinedragon.ripper",
   "displayName": "Divine Ripper",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "unity": "2020.3",
   "description": "Wrapper around AssetRipper and its API for Fire Emblem Engage modding."
 }


### PR DESCRIPTION
Allow components like `UniversalAdditionalCameraData` from `com.unity.render-pipelines.universal` to be correctly re-mapped - before this fix only the first class of the file could actually be matched.

How to verify:

Check how it's broken currently.
1. Create a fresh project.
2. Without loading this branch, rip any map, such as `fe_scenes_fld_m001.bundle`.
3. Open the scene and check `CameraSet`  -> `BmapCamera`
4. Observe that there is a script missing. <img width="568" height="300" alt="image" src="https://github.com/user-attachments/assets/9d6edfdf-fb15-4613-a32c-9c784aca87c4" />


Check how this branch fixes it.
5. Delete the entire ripped map folder (or make a new Unity project)
6. Load this branch.
7. Rip the same map.
8. Open the scene and check `CameraSet`  -> `BmapCamera`.
9. Observe that the script is no longer missing. <img width="568" height="266" alt="image" src="https://github.com/user-attachments/assets/920cca78-caba-4959-b894-492277231e67" />

Sanity check:
10. Ensure that a spring-boned unit works, such as `fe_assets_unit/model/ubody/dnc0am/c403/prefabs/ubody_dnc0am_c403.bundle` still has its spring bone components mapped correctly.


